### PR TITLE
Fixed changelog loading ui problems and version detection when integrated

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1,348 +1,286 @@
-﻿<!DOCTYPE html>
-<html class="no-js isBF">
-<head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>ButterFlight - Blackbox Explorer Changelog</title>
-    <link rel="icon" type="image/png" href="images/bf_icon_128.png">
-    <link rel="stylesheet" href="css/bootstrap.min.css">
-    <link rel="stylesheet" href="css/bootstrap-theme.min.css">
-    <style>
-        html, body {
-            overflow-y:auto;
-        }
-        .log {
-            line-height: 17px;
-            padding: 3px;
-        }
-        .log span {
-            display: block;
-            font-weight: bold;
-            padding-bottom: 5px;
-            border-bottom: 1px solid #ddd;
-        }
-        .log ul {
-            margin: 5px 0 20px 10px;
-        }
-        .log li {
-            font-weight: normal;
-            margin-bottom: 5px;
-        }
-        .log p {
-            margin-bottom: 20px;
-        }
-        .notes {
-            padding-left: 30px;
-            padding-right: 15px;
-        }
-    </style>
-</head>
-<body>
-<div class="log">
-    <h2> 3.1.0 - Butterflight Configurator Integration</h2>
+﻿
+<span> 3.1.0 - Butterflight Configurator Integration</span>
+<ul>
+    <li>New "Close" button on the toolbar</li>
+    <li>Fixed HTML issues that prevented opening some of the dialogs</li>
+    <li>Fixed buttons jumping left-right on hover due to incorrectly applied box shaows</li>
+    <li>Links from the index page now always open in a new window (browser)</li>
+    <li>Modifications for Butterflight Configurator integration</li>
+    <li>Changed UI theme to fit Butterflight Configurator colors</li>
+</ul>
 
+<span> 3.0.0 - Standalone app</span>
+<ul>
+    <li>Release of standalone app</li>
+</ul>
+
+<span> 2.5.13 - Minor Fixes</span>
+<ul>
+    <li>Version fixes</li>
+</ul>
+
+<span> 2.5.12 - Minor Fixes</span>
+<ul>
+    <li>3.2 support</li>
+</ul>
+
+<span> 2.5.11 - Minor Fixes</span>
+<ul>
+    <li>Remove scaling from PID's in info tab</li>
+    <li>Added new modes and features</li>
+</ul>
+
+<span> 2.5.10 - Minor Bug Fixes</span>
+<ul>
+    <li>Bump version to v2.5.10</li>
+    <li>Correct Log Sync to Time entry field.</li>
+    <li>Add additional 3.1 parameters</li>
+    <li>Reorganise PID other</li>
+</ul>
+
+<span> 2.5.9 - Minor Bug Fixes</span>
+<p>Observations during BF3.1.0 Release Candidate Testing.</p>
+<ul>
+    <li>Bump version to v2.5.9</li>
+    <li>DSHOT protocol list order revised on log header.</li>
+    <li>DSHOT1200 protocol added to log header.</li>
+</ul>
+
+<span> 2.5.8 - DShot Logging and Minor Bug Fixes</span>
+<p>Some fixes in response to user observations.</p>
+<ul>
+    <li>Bump version to v2.5.8</li>
+    <li>Compatibility with Version 3.1.0 of ButterFlight</li>
+    <li>Fix to Analyser display going blank for users using logging to onboard flash memory.</li>
+    <li>Always start with the values table hidden; pressing key 'T' will toggle the table; pressing the toolbar button will put it back at the bottom of the graph.</li>
+    <li>Fix Issue #36; viewer was not parsing version number correctly for filter scaling. Refactored functions to use library semver.</li>
+    <li>UI Overhall; improved handling for smaller screens.</li>
+    <li>Changelog added to Welcome screen</li>
+    <li>Add DShot to header dialog and scale motors independently to rcCommand[Throttle]</li>
+    <li>Update to gyro scale for BF 3.1.0; logged data is now scaled in the flight controller.</li>
+    <li>Add new debug fields to header and logs.</li>
+    <li>Add OSD and ESC features options to header dialog.</li>
+    <li>Add new BF3.1.0 parameters to header dialog.</li>
+    <li>Add user setting to show raw values on legend.</li>
+    <li>Correct VBAT scaling for BF3.1.0.</li>
+</ul>
+
+<span> 2.5.7 - Minor Bug Fixes and Feature Improvements</span>
+<ul>
+    <li>Bump version to v2.5.7</li>
+    <li>Correct case on Mode_x.png icons to prevent file not found on user settings dialog.</li>
+    <li>Update of video export vendor function from cleanflight/master; many thanks to @thenickdude. This is for users experiencing difficulties (linux?) generating video exports. Issue #30.</li>
+    <li>Added filename extension .BFL to auto-detect large log files; thanks to @mikeller</li>
+    <li>Mousewheel controls update as per feature request #31;</li>
+    <li>Add remove all button to graph config dialog #34; this is a port of the original viewer feature added by StewLG.</li>
+    <li>Added new log header parameters for second gyro notch filter.</li>
+    <li>Removed x100 frequency scaling for BF 3.0.1 to keep in sync with latest BF</li>
+    <li>Minor HTML code tidy-up for header dialog.</li>
+    <li>Add user setting to invert yaw on stick display. Off is normal; On is inverted.</li>
+    <li>Add user setting to apply hanning window to analyser FFT.</li>
+    <li>Add snap points to analyser zoom bars; to make it easier to get back to zoom level x1</li>
+    <li>Scale the colour gradient based upon zoom level so that zooming the fft doesn't push the bars into the red.</li>
+    <li>Improve graph background, add transparent gradient for better contrast.</li>
+</ul>
+
+<div class="notes">
+<h3>Notes</h3>
+
+<h4>Log file extension</h4>
+
+<p>BB Viewer attempts to determine the file type you are opening by examining the file extension first. Where no file extension is used in the name,
+    then BB Viewer will guess the type of file; which is usually fine for small log files (<10MB). </p>
+    <p>For log files larger than 10MB, then BB Viewer guesses they are video files and tries to load it (and fails because it is not a video)</p>
+    <p>So as a tip, it's best to use a file extension when you save your logs.</p>
+    <p>The file extensions that are automatically recognised are: -</p>
+<ul>
+    <li>.TXT, .CFL, .BFL and .LOG as log files,</li>
+    <li>.AVI, .MOV, .MP4, .MPEG as video files,</li>
+    <li>.JSON as workspace backups</li>
+</ul>
+
+<p>If it is not one of those extensions, it takes a guess on the type by file size (if file-size < 10MB then Log file else its a video);</p>
+
+<h4>Mousewheel Improvements</h4>
+<p>As you are probably already aware, scrolling the mouse wheel whilst the mouse pointer is over the graph will move the timeline forwards and backwards: -</p>
+<ul>
+    <li> Scrolling moves the timeline,</li>
+    <li>Scrolling whilst holding the SHIFT key, zooms the timeline</li>
+    <li>Scrolling whilst holding the ALY key, speeds up the zooming of the timeline.</li>
+</ul>
+
+<p>But now, thanks to suggestions from Joshua Bardwell, the mouse wheel functionality has been extended...
+    With the mouse pointer over a field in the graph legend...</p>
+<ul>
+    <li>Scrolling will dynamically adjust the SMOOTHING for the field.</li>
+    <li>Scrolling whilst holding the SHIFT key,adjusts the ZOOM for the field</li>
+    <li>Scrolling whilst holding the ALT key, adjusts the EXPO for the field.</li>
+</ul>
+
+<p>With the mouse pointer over the field group heading and then scrolling the mouse-wheel will adjust all fields within the group at the same time.</p>
+<p>Finally, if you "click" the middle mouse button, then the dynamic settings go back to the values you first set in the graph config dialog when
+    choosing the fields. Again, clicking on a single field will reset just that field, clicking on the group header will reset all pens within the group.</p>
+<p>So it is no longer necessary to keep going into the graph config dialog to adjust the values; just use the mouse wheel...</p>
+<p>The smoothing, zooming and expo dynamic changing above do not affect workspaces so you can always go back to your preferred settings by re-selecting the workspace.</p>
+
+<p>You will also notice now that to scroll the whole page using the mouse-wheel, you must move the pointer off both the graph and legend areas
+    (e.g move the pointer to the toolbar area and then scroll the wheel.</p>
+
+<h4>Grids</h4>
+<p>
     <ul>
-        <li>New "Close" button on the toolbar</li>
-        <li>Fixed HTML issues that prevented opening some of the dialogs</li>
-        <li>Fixed buttons jumping left-right on hover due to incorrectly applied box shaows</li>
-        <li>Links from the index page now always open in a new window (browser)</li>
-        <li>Modifications for Butterflight Configurator integration</li>
-        <li>Changed UI theme to fit Butterflight Configurator colors</li>
-    </ul>
-    <h2> 3.0.0 - Standalone app</h2>
-
-    <ul>
-        <li>Release of standalone app</li>
-    </ul>
-    <h2> 2.5.13 - Minor Fixes</h2>
-
-    <ul>
-        <li>Version fixes</li>
-    </ul>
-    <h2> 2.5.12 - Minor Fixes</h2>
-
-    <ul>
-        <li>3.2 support</li>
-    </ul>
-    <h2> 2.5.11 - Minor Fixes</h2>
-
-    <ul>
-        <li>Remove scaling from PID's in info tab</li>
-        <li>Added new modes and features</li>
-    </ul>
-    <h2> 2.5.10 - Minor Bug Fixes</h2>
-
-    <ul>
-        <li>Bump version to v2.5.10</li>
-        <li>Correct Log Sync to Time entry field.</li>
-        <li>Add additional 3.1 parameters</li>
-        <li>Reorganise PID other</li>
-    </ul>
-
-    <h2> 2.5.9 - Minor Bug Fixes</h2>
-
-    <p>Observations during BF3.1.0 Release Candidate Testing.</p>
-
-    <ul>
-        <li>Bump version to v2.5.9</li>
-        <li>DSHOT protocol list order revised on log header.</li>
-        <li>DSHOT1200 protocol added to log header.</li>
-    </ul>
-
-    <h2> 2.5.8 - DShot Logging and Minor Bug Fixes</h2>
-
-    <p>Some fixes in response to user observations.</p>
-
-    <ul>
-        <li>Bump version to v2.5.8</li>
-        <li>Compatibility with Version 3.1.0 of ButterFlight</li>
-        <li>Fix to Analyser display going blank for users using logging to onboard flash memory.</li>
-        <li>Always start with the values table hidden; pressing key 'T' will toggle the table; pressing the toolbar button will put it back at the bottom of the graph.</li>
-        <li>Fix Issue #36; viewer was not parsing version number correctly for filter scaling. Refactored functions to use library semver.</li>
-        <li>UI Overhall; improved handling for smaller screens.</li>
-        <li>Changelog added to Welcome screen</li>
-        <li>Add DShot to header dialog and scale motors independently to rcCommand[Throttle]</li>
-        <li>Update to gyro scale for BF 3.1.0; logged data is now scaled in the flight controller.</li>
-        <li>Add new debug fields to header and logs.</li>
-        <li>Add OSD and ESC features options to header dialog.</li>
-        <li>Add new BF3.1.0 parameters to header dialog.</li>
-        <li>Add user setting to show raw values on legend.</li>
-        <li>Correct VBAT scaling for BF3.1.0.</li>
-    </ul>
-
-    <h2> 2.5.7 - Minor Bug Fixes and Feature Improvements</h2>
-    <ul>
-
-        <li>Bump version to v2.5.7</li>
-        <li>Correct case on Mode_x.png icons to prevent file not found on user settings dialog.</li>
-        <li>Update of video export vendor function from cleanflight/master; many thanks to @thenickdude. This is for users experiencing difficulties (linux?) generating video exports. Issue #30.</li>
-        <li>Added filename extension .BFL to auto-detect large log files; thanks to @mikeller</li>
-        <li>Mousewheel controls update as per feature request #31;</li>
-        <li>Add remove all button to graph config dialog #34; this is a port of the original viewer feature added by StewLG.</li>
-        <li>Added new log header parameters for second gyro notch filter.</li>
-        <li>Removed x100 frequency scaling for BF 3.0.1 to keep in sync with latest BF</li>
-        <li>Minor HTML code tidy-up for header dialog.</li>
-        <li>Add user setting to invert yaw on stick display. Off is normal; On is inverted.</li>
-        <li>Add user setting to apply hanning window to analyser FFT.</li>
-        <li>Add snap points to analyser zoom bars; to make it easier to get back to zoom level x1</li>
-        <li>Scale the colour gradient based upon zoom level so that zooming the fft doesn't push the bars into the red.</li>
-        <li>Improve graph background, add transparent gradient for better contrast.</li>
-
-    </ul>
-    <div class="notes">
-    <h3>Notes</h3>
-
-    <h4>Log file extension</h4>
-
-    <p>BB Viewer attempts to determine the file type you are opening by examining the file extension first. Where no file extension is used in the name,
-        then BB Viewer will guess the type of file; which is usually fine for small log files (<10MB). </p>
-        <p>For log files larger than 10MB, then BB Viewer guesses they are video files and tries to load it (and fails because it is not a video)</p>
-        <p>So as a tip, it's best to use a file extension when you save your logs.</p>
-        <p>The file extensions that are automatically recognised are: -</p>
-    <ul>
-        <li>.TXT, .CFL, .BFL and .LOG as log files,</li>
-        <li>.AVI, .MOV, .MP4, .MPEG as video files,</li>
-        <li>.JSON as workspace backups</li>
-    </ul>
-
-    <p>If it is not one of those extensions, it takes a guess on the type by file size (if file-size < 10MB then Log file else its a video);</p>
-
-    <h4>Mousewheel Improvements</h4>
-    <p>
-        As you are probably already aware, scrolling the mouse wheel whilst the mouse pointer is over the graph will move the timeline forwards and backwards: -
-    <ul>
-        <li> Scrolling moves the timeline,</li>
-        <li>Scrolling whilst holding the SHIFT key, zooms the timeline</li>
-        <li>Scrolling whilst holding the ALY key, speeds up the zooming of the timeline.</li>
-    </ul>
-        <p>But now, thanks to suggestions from Joshua Bardwell, the mouse wheel functionality has been extended...
-            With the mouse pointer over a field in the graph legend...</p>
-     <ul>
-        <li>Scrolling will dynamically adjust the SMOOTHING for the field.</li>
-        <li>Scrolling whilst holding the SHIFT key,adjusts the ZOOM for the field</li>
-        <li>Scrolling whilst holding the ALT key, adjusts the EXPO for the field.</li>
-    </ul>
-
-    <p>With the mouse pointer over the field group heading and then scrolling the mouse-wheel will adjust all fields within the group at the same time.</p>
-    <p>Finally, if you "click" the middle mouse button, then the dynamic settings go back to the values you first set in the graph config dialog when
-        choosing the fields. Again, clicking on a single field will reset just that field, clicking on the group header will reset all pens within the group.</p>
-    <p>So it is no longer necessary to keep going into the graph config dialog to adjust the values; just use the mouse wheel...</p>
-    <p>The smoothing, zooming and expo dynamic changing above do not affect workspaces so you can always go back to your preferred settings by re-selecting the workspace.</p>
-
-    <p>You will also notice now that to scroll the whole page using the mouse-wheel, you must move the pointer off both the graph and legend areas
-        (e.g move the pointer to the toolbar area and then scroll the wheel.</p>
-    <h4>Grids</h4>
-    <p>
-        <ul>
         <li>TIP 1: It is easier to see the effect of the zooming and expo adjustment if the graph has the grid displayed... to display a grid for a field,
             then ALT left-click a field and the grid will be shown for that field.</li>
         <li>TIP 2: After you have selected a grid to display (using TIP 1); pressing the 'G' key will quickly toggle the grid on/off.</li>
-        </ul>
-    </p>
-    </div>
-
-    <h2>2.5.6 - Some minor field name relabelling.</h2>
-    <ul>
-        <li>Version updated to 2.5.6</li>
-        <li>rcCommands[] fields re-labelled as setpointRate[] fields to reflect their actual use as the setpoints into the PID controllers.</li>
-        <li>debug[] fields for debug mode "NOTCH" corrected to gyro_preNotch[] as per revision in RC14.</li>
     </ul>
+</p>
+</div>
 
-    <h2>2.5.5 - Minor code cleanups and re-scaling of rate calculations (for ButterFlight v3.0.0 RC12).</h2>
+<span>2.5.6 - Some minor field name relabelling.</span>
+<ul>
+    <li>Version updated to 2.5.6</li>
+    <li>rcCommands[] fields re-labelled as setpointRate[] fields to reflect their actual use as the setpoints into the PID controllers.</li>
+    <li>debug[] fields for debug mode "NOTCH" corrected to gyro_preNotch[] as per revision in RC14.</li>
+</ul>
 
-    <ul>
-        <li>Version updated to 2.5.5</li>
-        <li>Fixed #27 selecting rcCommand[all] will now scale pens individually.</li>
-        <li>Updated rate calculation to match new rates in ButterFlight v3.0.0 RC12.</li>
-        <li>Updated Analyser window start/end times to allow for logs that start after or cross over the 5 min boundary (for those logging using a switch).</li>
-        <li>Corrected Log Sync Forward/Backwards buttons (thanks Joshua Bardwell for finding that one); the graph window now updates immediately after button is pressed.</li>
-        <li>Removed Obsolete parameters from header.</li>
-    </ul>
+<span>2.5.5 - Minor code cleanups and re-scaling of rate calculations (for ButterFlight v3.0.0 RC12).</span>
+<ul>
+    <li>Version updated to 2.5.5</li>
+    <li>Fixed #27 selecting rcCommand[all] will now scale pens individually.</li>
+    <li>Updated rate calculation to match new rates in ButterFlight v3.0.0 RC12.</li>
+    <li>Updated Analyser window start/end times to allow for logs that start after or cross over the 5 min boundary (for those logging using a switch).</li>
+    <li>Corrected Log Sync Forward/Backwards buttons (thanks Joshua Bardwell for finding that one); the graph window now updates immediately after button is pressed.</li>
+    <li>Removed Obsolete parameters from header.</li>
+</ul>
 
-    <h2>2.5.4 - Mainly User Interface Tweaks.</h2>
+<span>2.5.4 - Mainly User Interface Tweaks.</span>
+<ul>
+    <li>Version number updated to 2.5.4</li>
+    <li>Zoom Sliders attached to analyser window rather than graph window. See Issue #23</li>
+    <li>Tooltips adjusted for better readability (changed colour and position); Window scrollbars corrected when run as Chrome App #18, #19 and #20.</li>
+    <li>Added Icon and page title for users running in a browser window.</li>
+    <li>Increased the size of the analyser window filter text when shown in fullscreen mode.</li>
+</ul>
 
-    <ul>
-        <li>Version number updated to 2.5.4</li>
-        <li>Zoom Sliders attached to analyser window rather than graph window. See Issue #23</li>
-        <li>Tooltips adjusted for better readability (changed colour and position); Window scrollbars corrected when run as Chrome App #18, #19 and #20.</li>
-        <li>Added Icon and page title for users running in a browser window.</li>
-        <li>Increased the size of the analyser window filter text when shown in fullscreen mode.</li>
-    </ul>
+<span>2.5.3 - Patch Update for Notch Filter Widths</span>
+<ul>
+    <li>Version number increased to 2.5.3</li>
+    <li>Patch to correct the notch filter widths displayed on the analyser window. Range is now only visible when the cutoff frequency is above 0.</li>
+</ul>
 
-    <h2>2.5.3 - Patch Update for Notch Filter Widths</h2>
+<span>2.5.2 - Minor Bug Fixes and Analyser Tweaks</span>
+<p>Some fixes and modifications resulting from user suggestions.</p>
+<ul>
+    <li>Version number increased to 2.5.2</li>
+    <li>Bugfix #13 ; changing log file with analyser maximised causes analyser to shrink back to normal size but doesn't update the button on the tool banner.</li>
+    <li>Added scooter to analyser display window; holding SHIFT key whilst moving mouse over analyser window will show the frequency under the mouse. Suggestion #14.</li>
+    <li>Hide frequency labels for unused filters (e.g. if gyro_notch_hz is set to 0 (un-used) then don't show line for it on analyser window (de-clutter the window).</li>
+    <li>Hide frequency parameter labels for Dterm when analysing a Yaw field (as there is no D) and visa versa, only display Yaw LPF frequency parameter when on Yaw fields.</li>
+    <li>Notch filter lines on analyser window show the width of the notch from center to +/- cut-off frequency.</li>
+    <li>User can now choose part of log to analyse if they don't want to examine whole log (which is the default). Mark the start of the analyser window using key 'I' and the end of the analyser using key 'O' (for In/Out). Analysed portion of the log is highlighted in the same way as video export feature.</li>
+    <li>Some spelling corrections.</li>
+    <li>Added independent zoom controls to analyser window (when in fullscreen mode). Can now zoom in the frequency range so that you can ignore higher frequencies.</li>
+    <li>Amended tooltip default behaviour to "hover" only; to prevent tooltips sticking 'on' the page.</li>
+</ul>
 
-    <ul>
-        <li>Version number increased to 2.5.3</li>
-        <li>Patch to correct the notch filter widths displayed on the analyser window. Range is now only visible when the cutoff frequency is above 0.</li>
-    </ul>
+<span>2.5.1 - Header Updates and New Analyser</span>
+<p>This is a maintenance release.</p>
+<ul>
+    <li>Updated version number.</li>
+    <li>Modified header dialog to include new header fields for ButterFlight V3.0.0 RC6 (Notch filters/RC interpolation etc).</li>
+    <li>Status bar now shows gyro/pid/motor sync values (e.g. 250us 4k/2k/SYNCED or 250us 4k/4k/32k).</li>
+    <li>Accelerometer range extended from 3G to 16G to prevent graph clipping on high powered craft.</li>
+    <li>Thanks to Rav-Rav, a new enhanced analyser function has replaced the old dynamic one; this analyser is static but shows the noise for the whole log file in far greater detail.</li>
+    <li> When using ButterFlight debug mode feature (from the cli), debug fields on the viewer will be shown with their relevant field name, range and scaling; the debug_mode is logged in the header too (BF3.0.0 and later).</li>
+</ul>
 
-    <h2>2.5.2 - Minor Bug Fixes and Analyser Tweaks</h2>
-    <p>Some fixes and modifications resulting from user suggestions.</p>
+<span>2.5.0 - Grids, INAV Header Support and Stick Trails.</span>
+<p>New Features</p>
+<b>Now also available in chrome store!</b>
+<p>Some New Features and minor code cleanups</p>
+<ul>
+    <li>Added grid's to chart backgrounds;</li>
+    <li>Added Shortcut key 'G' to toggle the grids On, Off globally.</li>
+    <li>Thanks to DzikuVx; INAV header's can be displayed in viewer.</li>
+    <li>Added INAV logo and blue theme to header buttons, graph config dialog. (Theme is Green for Cleanflight, Orange for ButterFlight and Blue for INAV).</li>
+    <li>Gyro chart range increased to +/-2000deg/s was a minor calculation error that limited the gyro chart to approx +/-1500deg/s</li>
+    <li>Header update for ButterFlight v3.0; added fields gyro_notch_hz, gyro_notch_q, rc_smooth_interval and "Craft name"</li>
+    <li>Craft Name is now shown on status bar (if entered in CLI) and also at top of header dialog (ButterFlight v3.0 only).</li>
+    <li>PID Contoller type names on header updated for ButterFlight v3.0.</li>
+    <li>Stick Trails; This feature can be turned on from the User Settings dialog, will show a phosphor trail on the stick display that shows the movement of the sticks for the last 500ms.</li>
+    <li>Add tooltips to primary logger controls.</li>
+    <li>Thanks to BorisB, Added New Event names for ButterFlight Twitch Testing mode.</li>
+    <li>Added new version information to welcome page; A new button is available to download the the latest official release.</li>
+</ul>
 
-    <ul>
-        <li>Version number increased to 2.5.2</li>
-        <li>Bugfix #13 ; changing log file with analyser maximised causes analyser to shrink back to normal size but doesn't update the button on the tool banner.</li>
-        <li>Added scooter to analyser display window; holding SHIFT key whilst moving mouse over analyser window will show the frequency under the mouse. Suggestion #14.</li>
-        <li>Hide frequency labels for unused filters (e.g. if gyro_notch_hz is set to 0 (un-used) then don't show line for it on analyser window (de-clutter the window).</li>
-        <li>Hide frequency parameter labels for Dterm when analysing a Yaw field (as there is no D) and visa versa, only display Yaw LPF frequency parameter when on Yaw fields.</li>
-        <li>Notch filter lines on analyser window show the width of the notch from center to +/- cut-off frequency.</li>
-        <li>User can now choose part of log to analyse if they don't want to examine whole log (which is the default). Mark the start of the analyser window using key 'I' and the end of the analyser using key 'O' (for In/Out). Analysed portion of the log is highlighted in the same way as video export feature.</li>
-        <li>Some spelling corrections.</li>
-        <li>Added independent zoom controls to analyser window (when in fullscreen mode). Can now zoom in the frequency range so that you can ignore higher frequencies.</li>
-        <li>Amended tooltip default behaviour to "hover" only; to prevent tooltips sticking 'on' the page.</li>
-    </ul>
+<div class="notes">
+    <h3>Notes on Grid Background</h3>
 
-    <h2>2.5.1 - Header Updates and New Analyser</h2>
+    <p>By default, no grids are shown on the graphs.</p>
+    <p>To add a grid background to the chart, 'ALT' Click the graph field name that you want the grid to show for.</p>
+    <p>To select another field to show the grid for, 'ALT' click another field.</p>
+    <p>To remove the grid, 'ALT' click the field again (it is a toggle).</p>
+    <p>Grid settings are workspace aware, so you can have different configurations for each workspace. (Just save the workspace after you have setup the grid display).</p>
+    <p>With grids shown, pressing the 'G' key will toggle the grid display on/off globally so that you can quickly hide the grid.</p>
+    <p>The lines on the grid represent 100ms time slots and each horizontal gridline represents 20% of the range of the signal. It makes it easier to see how the expo setting for the graph emphasises the centre section of the graph.</p>
+</div>
 
-    <p>This is a maintenance release.</p>
-
-    <ul>
-        <li>Updated version number.</li>
-        <li>Modified header dialog to include new header fields for ButterFlight V3.0.0 RC6 (Notch filters/RC interpolation etc).</li>
-        <li>Status bar now shows gyro/pid/motor sync values (e.g. 250us 4k/2k/SYNCED or 250us 4k/4k/32k).</li>
-        <li>Accelerometer range extended from 3G to 16G to prevent graph clipping on high powered craft.</li>
-        <li>Thanks to Rav-Rav, a new enhanced analyser function has replaced the old dynamic one; this analyser is static but shows the noise for the whole log file in far greater detail.</li>
-        <li> When using ButterFlight debug mode feature (from the cli), debug fields on the viewer will be shown with their relevant field name, range and scaling; the debug_mode is logged in the header too (BF3.0.0 and later).</li>
-    </ul>
-
-    <h2>2.5.0 - Grids, INAV Header Support and Stick Trails.</h2>
-
-    <p>New Features</p>
-
-    <b>Now also available in chrome store!</b>
-
-    <p>Some New Features and minor code cleanups</p>
-
-    <ul>
-        <li>Added grid's to chart backgrounds;</li>
-        <li>Added Shortcut key 'G' to toggle the grids On, Off globally.</li>
-        <li>Thanks to DzikuVx; INAV header's can be displayed in viewer.</li>
-        <li>Added INAV logo and blue theme to header buttons, graph config dialog. (Theme is Green for Cleanflight, Orange for ButterFlight and Blue for INAV).</li>
-        <li>Gyro chart range increased to +/-2000deg/s was a minor calculation error that limited the gyro chart to approx +/-1500deg/s</li>
-        <li>Header update for ButterFlight v3.0; added fields gyro_notch_hz, gyro_notch_q, rc_smooth_interval and "Craft name"</li>
-        <li>Craft Name is now shown on status bar (if entered in CLI) and also at top of header dialog (ButterFlight v3.0 only).</li>
-        <li>PID Contoller type names on header updated for ButterFlight v3.0.</li>
-        <li>Stick Trails; This feature can be turned on from the User Settings dialog, will show a phosphor trail on the stick display that shows the movement of the sticks for the last 500ms.</li>
-        <li>Add tooltips to primary logger controls.</li>
-        <li>Thanks to BorisB, Added New Event names for ButterFlight Twitch Testing mode.</li>
-        <li>Added new version information to welcome page; A new button is available to download the the latest official release.</li>
-    </ul>
-
-    <div class="notes">
-        <h3>Notes on Grid Background</h3>
-
-        <p>By default, no grids are shown on the graphs.</p>
-
-        <p>To add a grid background to the chart, 'ALT' Click the graph field name that you want the grid to show for.</p>
-        <p>To select another field to show the grid for, 'ALT' click another field.</p>
-        <p>To remove the grid, 'ALT' click the field again (it is a toggle).</p>
-        <p>Grid settings are workspace aware, so you can have different configurations for each workspace. (Just save the workspace after you have setup the grid display).</p>
-
-        <p>With grids shown, pressing the 'G' key will toggle the grid display on/off globally so that you can quickly hide the grid.</p>
-
-        <p>The lines on the grid represent 100ms time slots and each horizontal gridline represents 20% of the range of the signal. It makes it easier to see how the expo setting for the graph emphasises the centre section of the graph.</p>
-    </div>
-
-    <h2>Other Changes prior to 2.5.0</h2>
-
-    <ul>
-        <li>Adjustable Line Widths</li>
-        <li>Single frame scrolling (Hold ALT key whilst using cursor left and right)</li>
-        <li>Drag/Drop re-ordering of graphs on the chart (works in the graph configuration dialog too).</li>
-        <li>New shortcut keys 'S' and 'X' to toggle on/off all smoothing and expo on the chart.</li>
-        <li>New Watermark feature to add your own logo to exported video's or live-streams.</li>
-        <li>New Lap Time feature to add timing information to your exported video's.</li>
-        <li>Complete Change Summary</li>
-        <li>Custom Stick Configurations for those that fly mode 1; stick display will now show correctly.</li>
-        <li>General Cosmetic Changes;</li>
-        <li>ButterFlight and Cleanflight logos displayed on header bar; autodetect log version to display correct logo.</li>
-        <li>Header popup window is disabled for Cleanflight users (as the information is not held in the log file yet).</li>
-        <li>New links on the welcome screen and title has been changed to the Enhanced Blackbox Explorer to distinguish it from the standard viewer.</li>
-        <li>Advanced User Dialog Box to allow user to adjust size and position of the overlay icons (craft, sticks and analyser view)</li>
-        <li>User configurable stick display,can now display the sticks with throttle % and roll,pitch,yaw in deg/s</li>
-        <li>Marker/Measure mode (M key) will now show the time difference directly on the graph when you scroll; also the calculated frequency is displayed to quickly measure noise (for example).</li>
-        <li>Log controls now locked to the top of the display so they are visible even if you scroll down the page.</li>
-        <li>The multiple log selection and dropdown is now shown in the graph legend for easier selection. (and to prevent it being hidden on lower resolution displays).</li>
-        <li>Selecting [all] fields in graph config will cyclically assign alternate colors to fields (starting with the selected color)</li>
-        <li>When entering filters on configuration file, the updating list would generate errors if the grep statement was invalid. (could only be seen in developer mode).</li>
-        <li>Video export now fixed (still no sound though :-( ); also if you hide an item on the graph display (hide the craft for example), then it will also be hidden on exported video.</li>
-        <li>Cleanup hide/display of popup table (key 'T'); originally if the table was hidden and you popped up the overlay, when you hid the table again, it would show at the bottom of the page; now it will return to its originally selected state.</li>
-        <li>You can load 2 configuration dump files; if you load a second one with the the word 'default' in its filename (e.g. ButterFlight V2.7.2 Default.txt) then this file will be used as a baseline for the first loaded file; all differences between the two files will be highlighted in red. Also, once a "default" file is loaded, it will be cached and autoloaded next time you open up the log viewer; thus you only have to re-load the "default" file if and when the default values are changed.</li>
-        <li>Header and Scaling now ButterFlight v2.8.0 compliant; will auto-detect version from log file and scale accordingly.</li>
-        <li>Analyser Crash fix for crash that occurs if switching between many logs repeatedly (more than 6 times per session).</li>
-        <li>Code improvements for operation in Linux.</li>
-        <li>Additional User Settings Dialog for custom motor mixes (for those not running a standard X quad). Note that this setting only affects the craft overlay icon that is displayed. Deselecting "Custom" will display craft the traditional way (this is the default, you only need to change it if you are running a special motor configuration).</li>
-        <li>When using the Marker function (M), the time offset from the marker also shows the frequency in Hz (so if you mark the peak of a wave, then scroll to the next peak, you can quickly see the frequency of the wave). Quickly identify the frequency of your noisy gyro's.</li>
-        <li>Shortcut key 'T' will toggle the field value table as an overlay; no need to keep scrolling down to look at the values; the table is still dynamic and will update if the the log is scrolled, played...</li>
-        <li>Users can select their own colors for the graph fields on the graph configuration dialog. Colors are workspace aware and can be set on a per workspace.</li>
-        <li>FOCUS, selecting the graph title on the legend will hide the other graphs leaving only the selected one displayed; selecting the title again will put them back.</li>
-        <li>The log filename is now in the header and the header is fixed so that it doesn't scroll off the top of the display.</li>
-        <li>The filter settings from the header are shown on the analyser screen for reference</li>
-        <li>Configurable relative graph heights.</li>
-        <li>Workspace Export and Load feature. (New Export button for workspaces shown on page header creates a file "workspaces.json" in your downloads folder, these can be renamed to whatever but MUST have the extension .json). To re-load saved workspaces from file, use the standard open log file/video to select the archived file.</li>
-        <li>Configuration Dump text file load and view; it is now possible to open up a "dump" file for the flight controller configuration. This has to be a text file, with extension .TXT and must include the "# dump" line near the top of the file for the viewer to recognise it as a configuration file (rather than a normal LOG.txt file). Simply copy the CLI dump output to a text file and save it as "something.txt". Use the standard open log file/video button to open the file. The name of the loaded file is shown on the status bar (bottom right). To view it, either click the name in the status bar or press key 'C' (pressing C repeatedly will toggle the display). The view is scrollable and there is a filter search feature if your looking for a particular entry.</li>
-        <li>Added new status bar feature.</li>
-        <li>Minor changes to tidy up log header to match released version of ButterFlight v2.7.0.</li>
-        <li>Noticed that the Smart Sync combination M and ALT M only worked if you dragged the graph in the positive direction only. This is now fixed so that you can sync backwards and forwards of the marked point.</li>
-        <li>Also moved the header and keyboard shortcut buttons off the legend and up into the view toolbar to maximise space for the legend.</li>
-        <li>New dialog box added to review extra log header data;</li>
-        <li>Added Keyboard Shortcut Pop-up dialog.</li>
-        <li>Added ability to maximise the analyser window.</li>
-        <li>Added bookmarks</li>
-        <li>Legend now shows values</li>
-        <li>New icon alongside legend fields to show that they can be clicked.</li>
-        <li>New View toolbar to allow user to hide/view overlays. (table, craft and sticks).</li>
-        <li>The graph smoothing, expo and scale automatically match the original log viewer settings when first adding the graph field to the chart; you can, of course, change these on the dialog to what you want, but at least you now know what the defaults were in the original log viewer.</li>
-        <li>Bug fix the 'Log Setup' dialog so that the log file does not have to be re-loaded after changing the settings.</li>
-        <li>Fixed bug where the Anaylser would cause a crash after loading a log file 6 times.</li>
-        <li>Fixed Issue #6.</li>
-        <li>Added user configurable time to main chart window; user can now enter the desired log time to view directly without the need to scroll.</li>
-        <li>Added measure mode to graph; pressing 'M' will put a marker on the graph; then the difference between the current time and the marker is displayed in the toolbar. Pressing 'M' again removes the marker.</li>
-        <li>Easy log/video sync, press 'M' on the log to mark an event (start of flip or roll), then scroll until the first video frame that shows the event (video frame shows start of corresponding roll or flip). Now press [Alt]M to move the log/video sync to this point. 8 New Feature : Workspaces;</li>
-        <li>Shortcut Keys Added</li>
-        <li>Mouse Wheel Controls Added</li>
-        <li>Custom Field Smoothing, Expo and Zoom</li>
-    </ul>
-
-    </div>
-</body>
+<span>Other Changes prior to 2.5.0</span>
+<ul>
+    <li>Adjustable Line Widths</li>
+    <li>Single frame scrolling (Hold ALT key whilst using cursor left and right)</li>
+    <li>Drag/Drop re-ordering of graphs on the chart (works in the graph configuration dialog too).</li>
+    <li>New shortcut keys 'S' and 'X' to toggle on/off all smoothing and expo on the chart.</li>
+    <li>New Watermark feature to add your own logo to exported video's or live-streams.</li>
+    <li>New Lap Time feature to add timing information to your exported video's.</li>
+    <li>Complete Change Summary</li>
+    <li>Custom Stick Configurations for those that fly mode 1; stick display will now show correctly.</li>
+    <li>General Cosmetic Changes;</li>
+    <li>ButterFlight and Cleanflight logos displayed on header bar; autodetect log version to display correct logo.</li>
+    <li>Header popup window is disabled for Cleanflight users (as the information is not held in the log file yet).</li>
+    <li>New links on the welcome screen and title has been changed to the Enhanced Blackbox Explorer to distinguish it from the standard viewer.</li>
+    <li>Advanced User Dialog Box to allow user to adjust size and position of the overlay icons (craft, sticks and analyser view)</li>
+    <li>User configurable stick display,can now display the sticks with throttle % and roll,pitch,yaw in deg/s</li>
+    <li>Marker/Measure mode (M key) will now show the time difference directly on the graph when you scroll; also the calculated frequency is displayed to quickly measure noise (for example).</li>
+    <li>Log controls now locked to the top of the display so they are visible even if you scroll down the page.</li>
+    <li>The multiple log selection and dropdown is now shown in the graph legend for easier selection. (and to prevent it being hidden on lower resolution displays).</li>
+    <li>Selecting [all] fields in graph config will cyclically assign alternate colors to fields (starting with the selected color)</li>
+    <li>When entering filters on configuration file, the updating list would generate errors if the grep statement was invalid. (could only be seen in developer mode).</li>
+    <li>Video export now fixed (still no sound though :-( ); also if you hide an item on the graph display (hide the craft for example), then it will also be hidden on exported video.</li>
+    <li>Cleanup hide/display of popup table (key 'T'); originally if the table was hidden and you popped up the overlay, when you hid the table again, it would show at the bottom of the page; now it will return to its originally selected state.</li>
+    <li>You can load 2 configuration dump files; if you load a second one with the the word 'default' in its filename (e.g. ButterFlight V2.7.2 Default.txt) then this file will be used as a baseline for the first loaded file; all differences between the two files will be highlighted in red. Also, once a "default" file is loaded, it will be cached and autoloaded next time you open up the log viewer; thus you only have to re-load the "default" file if and when the default values are changed.</li>
+    <li>Header and Scaling now ButterFlight v2.8.0 compliant; will auto-detect version from log file and scale accordingly.</li>
+    <li>Analyser Crash fix for crash that occurs if switching between many logs repeatedly (more than 6 times per session).</li>
+    <li>Code improvements for operation in Linux.</li>
+    <li>Additional User Settings Dialog for custom motor mixes (for those not running a standard X quad). Note that this setting only affects the craft overlay icon that is displayed. Deselecting "Custom" will display craft the traditional way (this is the default, you only need to change it if you are running a special motor configuration).</li>
+    <li>When using the Marker function (M), the time offset from the marker also shows the frequency in Hz (so if you mark the peak of a wave, then scroll to the next peak, you can quickly see the frequency of the wave). Quickly identify the frequency of your noisy gyro's.</li>
+    <li>Shortcut key 'T' will toggle the field value table as an overlay; no need to keep scrolling down to look at the values; the table is still dynamic and will update if the the log is scrolled, played...</li>
+    <li>Users can select their own colors for the graph fields on the graph configuration dialog. Colors are workspace aware and can be set on a per workspace.</li>
+    <li>FOCUS, selecting the graph title on the legend will hide the other graphs leaving only the selected one displayed; selecting the title again will put them back.</li>
+    <li>The log filename is now in the header and the header is fixed so that it doesn't scroll off the top of the display.</li>
+    <li>The filter settings from the header are shown on the analyser screen for reference</li>
+    <li>Configurable relative graph heights.</li>
+    <li>Workspace Export and Load feature. (New Export button for workspaces shown on page header creates a file "workspaces.json" in your downloads folder, these can be renamed to whatever but MUST have the extension .json). To re-load saved workspaces from file, use the standard open log file/video to select the archived file.</li>
+    <li>Configuration Dump text file load and view; it is now possible to open up a "dump" file for the flight controller configuration. This has to be a text file, with extension .TXT and must include the "# dump" line near the top of the file for the viewer to recognise it as a configuration file (rather than a normal LOG.txt file). Simply copy the CLI dump output to a text file and save it as "something.txt". Use the standard open log file/video button to open the file. The name of the loaded file is shown on the status bar (bottom right). To view it, either click the name in the status bar or press key 'C' (pressing C repeatedly will toggle the display). The view is scrollable and there is a filter search feature if your looking for a particular entry.</li>
+    <li>Added new status bar feature.</li>
+    <li>Minor changes to tidy up log header to match released version of ButterFlight v2.7.0.</li>
+    <li>Noticed that the Smart Sync combination M and ALT M only worked if you dragged the graph in the positive direction only. This is now fixed so that you can sync backwards and forwards of the marked point.</li>
+    <li>Also moved the header and keyboard shortcut buttons off the legend and up into the view toolbar to maximise space for the legend.</li>
+    <li>New dialog box added to review extra log header data;</li>
+    <li>Added Keyboard Shortcut Pop-up dialog.</li>
+    <li>Added ability to maximise the analyser window.</li>
+    <li>Added bookmarks</li>
+    <li>Legend now shows values</li>
+    <li>New icon alongside legend fields to show that they can be clicked.</li>
+    <li>New View toolbar to allow user to hide/view overlays. (table, craft and sticks).</li>
+    <li>The graph smoothing, expo and scale automatically match the original log viewer settings when first adding the graph field to the chart; you can, of course, change these on the dialog to what you want, but at least you now know what the defaults were in the original log viewer.</li>
+    <li>Bug fix the 'Log Setup' dialog so that the log file does not have to be re-loaded after changing the settings.</li>
+    <li>Fixed bug where the Anaylser would cause a crash after loading a log file 6 times.</li>
+    <li>Fixed Issue #6.</li>
+    <li>Added user configurable time to main chart window; user can now enter the desired log time to view directly without the need to scroll.</li>
+    <li>Added measure mode to graph; pressing 'M' will put a marker on the graph; then the difference between the current time and the marker is displayed in the toolbar. Pressing 'M' again removes the marker.</li>
+    <li>Easy log/video sync, press 'M' on the log to mark an event (start of flip or roll), then scroll until the first video frame that shows the event (video frame shows start of corresponding roll or flip). Now press [Alt]M to move the log/video sync to this point. 8 New Feature : Workspaces;</li>
+    <li>Shortcut Keys Added</li>
+    <li>Mouse Wheel Controls Added</li>
+    <li>Custom Field Smoothing, Expo and Zoom</li>
+</ul>

--- a/changelog.html
+++ b/changelog.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html class="no-js isBF">
 <head>
     <meta charset="utf-8">
@@ -39,6 +39,16 @@
 </head>
 <body>
 <div class="log">
+    <h2> 3.1.0 - Butterflight Configurator Integration</h2>
+
+    <ul>
+        <li>New "Close" button on the toolbar</li>
+        <li>Fixed HTML issues that prevented opening some of the dialogs</li>
+        <li>Fixed buttons jumping left-right on hover due to incorrectly applied box shaows</li>
+        <li>Links from the index page now always open in a new window (browser)</li>
+        <li>Modifications for Butterflight Configurator integration</li>
+        <li>Changed UI theme to fit Butterflight Configurator colors</li>
+    </ul>
     <h2> 3.0.0 - Standalone app</h2>
 
     <ul>

--- a/css/main.css
+++ b/css/main.css
@@ -1254,9 +1254,9 @@ div#lap-timer td:first-child {
 
 #changelog .wrapper {
     height: 100%;
-    padding: 0 0;
-    border-left: 5px solid #ffbb00;
-    overflow: hidden;
+    padding: 0 20px;
+    border-left: 5px solid #f7931e;
+    overflow: auto;
     display: none;
 }
 
@@ -1265,7 +1265,8 @@ div#lap-timer td:first-child {
     top: 50px;
     right: 665px;
     position: absolute;
-    background: #ffbb00;
+    background: #f7931e;
+    cursor: pointer;
     border-radius: 5px 5px 0 0;
     border-bottom: none;
     height: 30px;
@@ -1276,6 +1277,8 @@ div#lap-timer td:first-child {
     padding: 5px 10px;
     width: 90px;
     text-align: center;
+    font-size: 14px;
+    text-decoration: none;
     color: #000;
 }
 
@@ -1284,23 +1287,51 @@ div#lap-timer td:first-child {
     font-size: 16px;
 }
 
-html.log_open #changelog {
+.welcome-pane.log_open #changelog {
     right: 0px;
     background: white;
 }
 
-html.log_open #changelog .wrapper {
+.welcome-pane.log_open #changelog .wrapper {
     display: block;
 }
 
 /* changelog content */
-#changelog iframe {
+#changelog .log{
+    line-height: 17px;
+}
+
+#changelog .log span {
+    display: block;
+    font-weight: bold;
+    padding-bottom: 5px;
+    border-bottom: 1px solid #ddd;
+}
+
+#changelog .log ul {
+    margin: 5px 0 20px 10px;
+}
+
+#changelog .log li {
+    font-weight: normal;
+    margin-bottom: 5px;
+}
+#changelog .log p {
+    margin-bottom: 20px;
+}
+
+#changelog .notes {
+    padding-left: 30px;
+    padding-right: 15px;
+}
+
+/*#changelog .log {
     border: 1px;
     width: calc(100% - 20px);
     border-style: solid;
     height: calc(100% - 20px);
     margin: 10px 10px 10px 10px;
-}
+}*/
 
 
 dialog {

--- a/index.html
+++ b/index.html
@@ -147,10 +147,13 @@
         <!-- the changelog floats outside of the page. -->
         <div id="changelog">
             <div class="button">
-                <a id="changelog_toggle" href="#">Changelog</a>
+                <a id="changelog_toggle">Changelog</a>
             </div>
             <div class="wrapper">
-                <iframe src="./changelog.html"></iframe>
+                <div class="title">ButterFlight - Blackbox Explorer Changelog</div>
+                <div class="log">
+                    <!--Changelog content loaded here-->
+                </div>
             </div>
         </div>
     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -994,17 +994,19 @@ function BlackboxLogViewer() {
             toggleOverrideStatus('graphGridOverride', 'has-grid-override');
         });
 
+        $("#changelog .log").load("./changelog.html");
+
         /** changelog trigger **/
         $("#changelog_toggle").on('click', function() {
             var state = $(this).data('state2');
             if (state) { // log closed
                 $("#changelog").animate({right: -695}, 200, function () {
-                    html.removeClass('log_open');
+                    $(".welcome-pane").removeClass('log_open');
                 });
                 state = false;
             } else { // log open
                 $("#changelog").animate({right: 0}, 200);
-                html.addClass('log_open');
+                $(".welcome-pane").addClass('log_open');
                 state = true;
             }
             $(this).text(state ? 'Close' : 'Changelog');
@@ -1906,7 +1908,7 @@ function getManifestVersion(manifest) {
         manifest = chrome.runtime.getManifest();
     }
 
-    var version = manifest.version_name;
+    var version = manifest.integrated_bbe_version;
     if (!version) {
         version = manifest.version;
     }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "ButterFlight - Blackbox Explorer",
   "description": "Interactive flight log viewer for ButterFlight",
-  "version": "3.0.0",
-  "version_name": "3.0.0-rc1",
+  "version": "3.1.0",
+  "version_name": "3.1.0-BTTR",
   "manifest_version": 2,
   "default_locale": "en",
   "app": {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,6 @@
   "name": "ButterFlight - Blackbox Explorer",
   "description": "Interactive flight log viewer for ButterFlight",
   "version": "3.1.0",
-  "version_name": "3.1.0-BTTR",
   "manifest_version": 2,
   "default_locale": "en",
   "app": {
@@ -14,5 +13,5 @@
        {"fileSystem": ["write"]},
        "storage"
    ],
-  "icons": { "128": "images/bf_icon_128.png" }
+  "icons": [{ "128": "images/bf_icon_128.png" }]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "butterflight-blackbox-explorer",
   "displayName": "Butterflight - Blackbox Explorer",
   "description": "Crossplatform blackbox analitics tool for Butterflight flight control system.",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "main": "main_nwjs.html",
   "bg-script": "background.js",
   "default_locale": "en",


### PR DESCRIPTION
- Fixed outdated load method of changelog.html
- Fixed a bug where opening the changelog whil running in the Butterflight Configurator would break the UI
- Fixed version detection when runnin in the Butteflight Configurator. From now on when we upgrade the integration in the configurator, the new version number (integrated_bbe_version") must be updated in the configurator's package.json
- Removed unnecessary elements from changelog.html
- Moved styles from changelog.html to main.css (temporary until full refactor)
- Incremented version to 3.1.0 for integration release